### PR TITLE
Add per-post syntax highlighting configuration

### DIFF
--- a/js/init-highlighting.js
+++ b/js/init-highlighting.js
@@ -1,0 +1,23 @@
+/**
+ * Initialize syntax highlighting for specified languages.
+ * @param {string[]} languages - Array of language names (e.g., ['fql', 'go'])
+ */
+function initHighlighting(languages) {
+  // Convert class names from shorthand to language- prefix
+  // e.g., class="fql" becomes class="language-fql"
+  if (languages && languages.length > 0) {
+    languages.forEach(lang => {
+      document.querySelectorAll(`.${lang}`).forEach(e => {
+        e.classList.replace(lang, `language-${lang}`);
+      });
+    });
+  }
+
+  // Run highlight.js on all code blocks
+  hljs.highlightAll();
+
+  // Ensure inline code blocks are also highlighted
+  document.querySelectorAll(":not(pre) > code[class^='language-']").forEach((e) => {
+    hljs.highlightElement(e);
+  });
+}

--- a/post.tmpl
+++ b/post.tmpl
@@ -6,11 +6,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
   <title>${title}</title>
   <link href="https://fonts.googleapis.com/css?family=Roboto|Merriweather" rel="stylesheet" />
+$if(languages)$
   <link rel="stylesheet" href="css/code.css" />
+$endif$
   <link rel="stylesheet" href="css/style.css" />
+$if(languages)$
   <script src="js/highlight.js"></script>
-  <script src="js/fql.js"></script>
-  <script src="js/go.js"></script>
+$for(languages)$
+  <script src="js/$languages$.js"></script>
+$endfor$
+  <script src="js/init-highlighting.js"></script>
+$endif$
 </head>
 <body>
 <header>
@@ -21,15 +27,9 @@
 <hr>
 ${body}
 </body>
+$if(languages)$
 <script>
-  document.querySelectorAll('.fql, .go').forEach(e => {
-    e.classList.replace('fql', 'language-fql');
-    e.classList.replace('go', 'language-go');
-  });
-
-  hljs.highlightAll();
-  document.querySelectorAll(":not(pre) > code[class^='language-']").forEach((e) => {
-    hljs.highlightElement(e);
-  });
+  initHighlighting([$for(languages)$'$languages$'$sep$, $endfor$]);
 </script>
+$endif$
 </html>

--- a/posts/20251227_mutex.md
+++ b/posts/20251227_mutex.md
@@ -5,14 +5,14 @@ languages: [fql, go]
 ...
 
 At work, I found myself in apparent need of synchronizing
-access to a shared resources. The actors requesting access
+access to a shared resource. The actors requesting access
 were two distributed services. Being fond and familiar with
 the "assembly language of databases", I knew I could
 implement a distributed mutex on top of Foundation DB. 
 
 Calling Foundation DB the "assembly language of databases"
 (something I once read on [Hacker News][]) is an
-exaggeration. Nonetheless, Foundation DB does provide a set
+exaggeration. Nonetheless, Foundation DB does provide a set of
 primitives which makes accessing distributed memory safe and
 graceful.
 
@@ -75,7 +75,7 @@ Foundation DB provides a special kind of subspace called
 a [directory][]. Traditional directory paths are mapped to
 short byte string prefixes. For instance, the path
 `/my/dir/path`{.fql} could be mapped to the prefix
-`0xfa3209`{.fql} Key-values written into this directory
+`0xfa3209`{.fql}. Key-values written into this directory
 would include this prefix.
 
 [directory]: https://apple.github.io/foundationdb/developer-guide.html#directories
@@ -245,10 +245,10 @@ the queue.
 // Blocks until the current client is the owner of the mutex. The `ctx`
 // argument includes a cancelation signal for aborting the operation.
 func (x *Mutex) Acquire(ctx context.Context, db fdb.Database) error {
-  // Attempts a non-blocking aquire. If it succeeds, we can return.
+  // Attempts a non-blocking acquire. If it succeeds, we can return.
   acquired, err := x.TryAcquire(db)
   if err != nil {
-    return fmt.Errorf("failed to try aquire: %w", err)
+    return fmt.Errorf("failed to try acquire: %w", err)
   }
   if acquired {
     return nil
@@ -336,7 +336,7 @@ func (x *Mutex) TryAcquire(db fdb.Database) (bool, error) {
     default:
       // Someone else is the owner (mutex is locked). Place
       // our name on the queue.
-      return false, x.enqueue(db, x.name)
+      return false, x.enqueue(tr, x.name)
     }
   })
   if err != nil {
@@ -376,7 +376,7 @@ client from acting on a stale read.
 
 In the sequence diagram above, take a look at the events
 happening between `t1` and `t2`. Because `client-A` reads
-the empty owner key, that key becomes a part of it's
+the empty owner key, that key becomes a part of its
 conflict range. `client-B` overwrites this key and commits
 before `client-A`. This causes `client-A`'s transaction to
 be rejected. Upon retrying the transaction, `client-A` sees
@@ -398,7 +398,7 @@ installation of Foundation DB works fine as well.
 For each test, I create a random subspace to isolate the
 reads and writes. This subspace is deleted after each test
 runs. For this isolation to work, you must ensure your
-client does all it's reads and writes within the context of
+client does all its reads and writes within the context of
 a [configurable subspace][].
 
 [configurable subspace]: https://github.com/janderland/fdb-mutex/blob/5075a63324ef2c49d517b714134bff003a45093a/mutex.go#L25
@@ -426,7 +426,7 @@ func runTest(t *testing.T, test testFn) {
   }
 
   // Schedule a destructor which deletes the directory
-  // (clearing all it's key-values) after the test is
+  // (clearing all its key-values) after the test is
   // complete.
   defer func() {
     err := directory.Root().Remove(db, []string{dirName})
@@ -461,7 +461,7 @@ func TestMarshaling(t *testing.T) {
       in := "name"
       out := UnpackQueueValue(PackQueueValue(in))
       require.Equal(out, in)
-  }
+  })
 }
 ```
 
@@ -484,7 +484,7 @@ like [server-side operations][], [manual conflict
 management][], or [transaction throttling][]. Take a look at
 the Foundation DB [documentation][] for more information. If
 you have any questions, drop by the Foundation DB
-[forums][]. If you see [me][] around, please say "hi". 😀
+[forums][]. If you see [me][] around, please say "hi".
 
 [server-side operations]: https://apple.github.io/foundationdb/developer-guide.html#atomic-operations
 [manual conflict management]: https://apple.github.io/foundationdb/developer-guide.html#snapshot-reads

--- a/posts/20251227_mutex.md
+++ b/posts/20251227_mutex.md
@@ -1,6 +1,7 @@
 ---
 title: Intro to Foundation DB via a Distributed Mutex
 date: 2025-12-27
+languages: [fql, go]
 ...
 
 At work, I found myself in apparent need of synchronizing


### PR DESCRIPTION
This change allows blog posts to specify which syntax highlighting languages they need via a 'languages' field in the YAML frontmatter. Only posts with code blocks will load the highlighting assets.

Changes:
- Created js/init-highlighting.js to contain initialization logic
- Updated post.tmpl to conditionally include code assets based on the languages field, dynamically loading only specified languages
- Updated mutex post to include languages: [fql, go] in frontmatter

Posts without the languages field won't load any code-related assets, improving page load performance for non-technical posts.

Also fixes several typos in the mutex post (its/it's, acquire spelling).